### PR TITLE
Fixed a bug in the static classifiers definition

### DIFF
--- a/lbjava/src/test/java/edu/illinois/cs/cogcomp/lbjava/features/PredefinedFeature.java
+++ b/lbjava/src/test/java/edu/illinois/cs/cogcomp/lbjava/features/PredefinedFeature.java
@@ -1,4 +1,4 @@
-package edu.illinois.cs.cogcomp.lbjava;
+package edu.illinois.cs.cogcomp.lbjava.features;
 
 import edu.illinois.cs.cogcomp.lbjava.classify.Classifier;
 import edu.illinois.cs.cogcomp.lbjava.classify.DiscretePrimitiveStringFeature;


### PR DESCRIPTION
Previously, the name of the containing class should be in the import statements
Now, you can use static classifiers with entire package imports
(e.g. `import edu.illinois.cs.cogcomp.lbjava.features.*;`)

FYI @mssammon @danr-ccg @xinbowu2 @pauljv92
