### PR TITLE
Added pruneUselessLabels to SparseNetworkLearner

### DIFF
--- a/lbjava-examples/pom.xml
+++ b/lbjava-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lbjava-project</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>LBJava</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>lbjava-maven-plugin</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
     </dependencies>
 
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>edu.illinois.cs.cogcomp</groupId>
                 <artifactId>lbjava-maven-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.2</version>
                 <configuration>
                     <gspFlag>${project.basedir}/src/main/java</gspFlag>
                     <dFlag>${project.basedir}/target/classes</dFlag>

--- a/lbjava-examples/pom.xml
+++ b/lbjava-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>lbjava-project</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/lbjava-mvn-plugin/pom.xml
+++ b/lbjava-mvn-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lbjava-project</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </parent>
 
     <artifactId>lbjava-maven-plugin</artifactId>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>LBJava</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/lbjava-mvn-plugin/pom.xml
+++ b/lbjava-mvn-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lbjava-project</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
     </parent>
 
     <artifactId>lbjava-maven-plugin</artifactId>

--- a/lbjava/pom.xml
+++ b/lbjava/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <artifactId>lbjava-project</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
     </parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/lbjava/pom.xml
+++ b/lbjava/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <artifactId>lbjava-project</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
     </parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/classify/DiscretePrimitiveStringFeature.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/classify/DiscretePrimitiveStringFeature.java
@@ -221,7 +221,7 @@ public class DiscretePrimitiveStringFeature extends DiscreteFeature {
      * @return The hash code of this feature.
      **/
     public int hashCode() {
-        return 31 * super.hashCode() + 17 * identifier.hashCode() + value.hashCode();
+        return super.hashCode() + 17 * identifier.hashCode() + value.hashCode();
     }
 
 
@@ -237,8 +237,7 @@ public class DiscretePrimitiveStringFeature extends DiscreteFeature {
             return false;
         if (o instanceof DiscretePrimitiveStringFeature) {
             DiscretePrimitiveStringFeature f = (DiscretePrimitiveStringFeature) o;
-            return identifier.equals(f.identifier) && valueIndex > -1 ? valueIndex == f.valueIndex
-                    : value.equals(f.value);
+            return identifier.equals(f.identifier) && value.equals(f.value);
         }
 
         DiscretePrimitiveFeature f = (DiscretePrimitiveFeature) o;

--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/Lexicon.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/learn/Lexicon.java
@@ -22,6 +22,7 @@ import edu.illinois.cs.cogcomp.lbjava.util.ByteString;
 import edu.illinois.cs.cogcomp.lbjava.util.ClassUtils;
 import edu.illinois.cs.cogcomp.lbjava.util.FVector;
 import edu.illinois.cs.cogcomp.lbjava.util.TableFormat;
+import gnu.trove.map.hash.THashMap;
 
 
 /**
@@ -132,7 +133,7 @@ public class Lexicon implements Cloneable, Serializable {
 
     // Member variables.
     /** The map of features to integer keys. */
-    protected Map lexicon;
+    protected Map<Feature, Integer> lexicon;
     /** The inverted map of integer keys to their features. */
     protected FVector lexiconInv;
     /** The encoding to use for new features added to this lexicon. */
@@ -182,7 +183,7 @@ public class Lexicon implements Cloneable, Serializable {
 
     /** Clears the data structures associated with this instance. */
     public void clear() {
-        lexicon = new HashMap();
+        lexicon = new THashMap();
         lexiconInv = new FVector();
         lexiconChildren = null;
         pruneCutoff = -1;
@@ -709,7 +710,7 @@ public class Lexicon implements Cloneable, Serializable {
         }
 
         if (lexicon != null) {
-            clone.lexicon = new HashMap();
+            clone.lexicon = new THashMap();
             clone.lexicon.putAll(lexicon);
         }
         clone.lexiconInv = (FVector) lexiconInv.clone();

--- a/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/parse/ArrayFileParser.java
+++ b/lbjava/src/main/java/edu/illinois/cs/cogcomp/lbjava/parse/ArrayFileParser.java
@@ -36,6 +36,8 @@ import edu.illinois.cs.cogcomp.lbjava.learn.Learner;
 public class ArrayFileParser implements Parser {
     /** Reader for file currently being parsed. */
     protected DataInputStream in;
+    /** the zip file must also be closed, if this is compressed file. */
+    protected ZipFile zipFile=null;
     /** The name of the file to parse. */
     protected String exampleFileName;
     /** A single array from which all examples can be parsed. */
@@ -190,13 +192,11 @@ public class ArrayFileParser implements Parser {
         try {
             if (exampleFileName != null) {
                 if (zipped) {
-                    ZipFile zip = new ZipFile(exampleFileName);
-                    in =
-                            new DataInputStream(new BufferedInputStream(zip.getInputStream(zip
+                    zipFile = new ZipFile(exampleFileName);
+                    in = new DataInputStream(new BufferedInputStream(zipFile.getInputStream(zipFile
                                     .getEntry(ExceptionlessInputStream.zipEntryName))));
                 } else
-                    in =
-                            new DataInputStream(new BufferedInputStream(new FileInputStream(
+                    in = new DataInputStream(new BufferedInputStream(new FileInputStream(
                                     exampleFileName)));
             } else if (zipped) {
                 ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(exampleData));
@@ -218,6 +218,9 @@ public class ArrayFileParser implements Parser {
             return;
         try {
             in.close();
+            if (zipFile != null) {
+            	zipFile.close();
+            }
         } catch (Exception e) {
             System.err.println("Can't close '" + exampleFileName + "':");
             e.printStackTrace();

--- a/lbjava/src/test/java/edu/illinois/cs/cogcomp/lbjava/SparseNetworkLearningPruneTest.java
+++ b/lbjava/src/test/java/edu/illinois/cs/cogcomp/lbjava/SparseNetworkLearningPruneTest.java
@@ -16,5 +16,4 @@ public class SparseNetworkLearningPruneTest {
 	@Test
 	public void test() {
 	}
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>edu.illinois.cs.cogcomp</groupId>
     <artifactId>lbjava-project</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
 
     <modules>
         <module>lbjava</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>edu.illinois.cs.cogcomp</groupId>
     <artifactId>lbjava-project</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 
     <modules>
         <module>lbjava</module>


### PR DESCRIPTION
This method will discard any classifiers for labels not in the list passed in. This is intended to
allow users to discard classifers for labels they are not interested in, but
may have uninteded side effects, like GPE labels being classified as PERSON.